### PR TITLE
rewrite devices to device (one)

### DIFF
--- a/src/pushover/data/attachment_message.rs
+++ b/src/pushover/data/attachment_message.rs
@@ -30,8 +30,8 @@ pub struct AttachmentMessage {
     pub sound: Option<String>,
     /// A Unix timestamp of your message's date and time to display to the user, rather than the time your message is received by our API
     pub timestamp: Option<String>, // Year 2038 proof :p
-    /// A list of device names to send the push notifications to, if you want to limit the notification to certain devices.
-    pub devices: Option<Vec<String>>,
+    /// A device name to send the push notifications to, if you want to limit the notification to a certain device.
+    pub device: Option<String>,
     /// A TTL (Time to Live) in seconds, after which the message will be automatically deleted from the recipient's inbox.
     /// Setting *ttl* to None or 0 prevents this auto removal.
     pub ttl: Option<u32>,
@@ -49,7 +49,7 @@ impl AttachmentMessage {
             .text("priority", self.priority.unwrap_or("".into()))
             .text("sound", self.sound.clone().unwrap_or("".into()))
             .text("timestamp", self.timestamp.unwrap_or("".into()))
-            .text("device", self.devices.clone().unwrap_or(vec!()).join(","))
+            .text("device", self.device.unwrap_or("".into()))
             .text("ttl", self.ttl.unwrap_or(0).to_string())
             .file("attachment", self.attachment.clone())
     }
@@ -68,7 +68,7 @@ impl Default for AttachmentMessage {
             priority: None,
             sound: None,
             timestamp: None,
-            devices: None,
+            device: None,
             ttl: None,
         }
     }

--- a/src/pushover/data/attachment_message_builder.rs
+++ b/src/pushover/data/attachment_message_builder.rs
@@ -1,5 +1,6 @@
 use std::io::Error;
 use std::io::ErrorKind;
+use crate::MessageBuilder;
 
 use crate::pushover::constants;
 
@@ -156,48 +157,16 @@ impl AttachmentMessageBuilder {
     }
 
     /// Add a device name to send the notification to.
-    /// 
-    /// Ignores if the device name is already in the list.
-    pub fn add_device(mut self, device_name: &str) -> AttachmentMessageBuilder {
-        type Devices = Vec<String>;
-
-        if device_name.trim().len() == 0 {
-            return self;
-        }
-
-        if self.build.devices.is_none() {
-            self.build.devices = Some(vec!());
-        } else {
-            let clone: Vec<String> = self.build.devices.clone().unwrap();
-            if clone.contains(&device_name.into()) {
-                return self;
-            }
-        }
-
-        let mut replacement_list: Devices = self.build.devices.clone().unwrap();
-        replacement_list.push(device_name.to_owned());
-        self.build.devices = Some(replacement_list);
-
+    ///
+    /// Overrides the current device if a new device name is set.
+    pub fn set_device(mut self, device_name: &str) -> AttachmentMessageBuilder {
+        self.build.device = Some(device_name.to_string());
         self
     }
 
-    /// Overrides the current devices list with device_names
-    pub fn set_devices(mut self, device_names: Vec<&str>) -> AttachmentMessageBuilder {
-        let device_names = device_names.iter().map(|x| x.to_string()).collect::<Vec<String>>();
-        self.build.devices = Some(device_names);
-        self
-    }
-
-    /// Merges the current devices list with device_names, duplicates are eliminated
-    pub fn merge_devices(mut self, device_names: Vec<&str>) -> AttachmentMessageBuilder {
-        for name in device_names {
-            self = self.add_device(name);
-        }
-        self
-    }
-
-    pub fn clear_devices_list(mut self) -> AttachmentMessageBuilder {
-        self.build.devices = None;
+    /// Clears the device if set.
+    pub fn remove_device(mut self) -> AttachmentMessageBuilder {
+        self.build.device = None;
         self
     }
 

--- a/src/pushover/data/attachment_message_builder.rs
+++ b/src/pushover/data/attachment_message_builder.rs
@@ -1,6 +1,5 @@
 use std::io::Error;
 use std::io::ErrorKind;
-use crate::MessageBuilder;
 
 use crate::pushover::constants;
 

--- a/src/pushover/data/message.rs
+++ b/src/pushover/data/message.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 
 #[derive(Debug, Clone, Serialize)]
 /**
-A message to be used in conjuction with the send_pushover_request function.
+A message to be used in conjunction with the send_pushover_request function.
 
 Note: It is preferred to create a Message through the MessageBuilder.
  **/
@@ -36,9 +36,9 @@ pub struct Message {
     /// A Unix timestamp of your message's date and time to display to the user, rather than the time your message is received by our API
     #[serde(skip_serializing_if = "Option::is_none")]
     pub timestamp: Option<u64>, // Year 2038 proof :p
-    /// A list of device names to send the push notifications to, if you want to limit the notification to certain devices.
+    /// A device name to send the push notifications to, if you want to limit the notification to a certain device.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub devices: Option<Vec<String>>,
+    pub device: Option<String>,
     /// A TTL (Time to Live) in seconds, after which the message will be automatically deleted from the recipient's inbox.
     /// Setting *ttl* to None or 0 prevents this auto removal.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -57,7 +57,7 @@ impl Default for Message {
             priority: None,
             sound: None,
             timestamp: None,
-            devices: None,
+            device: None,
             ttl: None,
         }
     }

--- a/src/pushover/data/message_builder.rs
+++ b/src/pushover/data/message_builder.rs
@@ -148,49 +148,16 @@ impl MessageBuilder {
     }
 
     /// Add a device name to send the notification to.
-    /// 
-    /// Ignores if the device name is already in the list.
-    pub fn add_device(mut self, device_name: &str) -> MessageBuilder {
-        type Devices = Vec<String>;
-
-        if device_name.trim().len() == 0 {
-            return self;
-        }
-
-        if self.build.devices.is_none() {
-            self.build.devices = Some(vec!());
-        } else {
-            let clone: Vec<String> = self.build.devices.clone().unwrap();
-            if clone.contains(&device_name.into()) {
-                return self;
-            }
-        }
-
-        let mut replacement_list: Devices = self.build.devices.clone().unwrap();
-        replacement_list.push(device_name.to_owned());
-        self.build.devices = Some(replacement_list);
-
+    ///
+    /// Overrides the current device if a new device name is set.
+    pub fn set_device(mut self, device_name: &str) -> MessageBuilder {
+        self.build.device = Some(device_name.to_string());
         self
     }
 
-    /// Overrides the current devices list with device_names
-    pub fn set_devices(mut self, device_names: Vec<&str>) -> MessageBuilder {
-        let device_names = device_names.iter().map(|x| x.to_string()).collect::<Vec<String>>();
-        self.build.devices = Some(device_names);
-        self
-    }
-
-    /// Merges the current devices list with device_names, duplicates are eliminated
-    pub fn merge_devices(mut self, device_names: Vec<&str>) -> MessageBuilder {
-        for name in device_names {
-            self = self.add_device(name);
-        }
-        self
-    }
-
-    /// Clears the devices list entirely
-    pub fn clear_devices_list(mut self) -> MessageBuilder {
-        self.build.devices = None;
+    /// Clears the device if set.
+    pub fn remove_device(mut self) -> MessageBuilder {
+        self.build.device = None;
         self
     }
 

--- a/src/tests/github_actions_friendly.rs
+++ b/src/tests/github_actions_friendly.rs
@@ -1,5 +1,3 @@
-use std::vec;
-
 use crate::{AttachmentMessageBuilder, Message, MessageBuilder, PushoverSound};
 
 #[test]
@@ -20,9 +18,8 @@ pub fn test_message_builder() {
         .set_priority(100) // "Error": Out of the [-2, 2] boundary -> Should be reset to 0
         .set_sound(PushoverSound::CASHREGISTER)
         .set_timestamp(1635861224)
-        .add_device("device a")
-        .add_device("device b")
-        .add_device("device a") // Duplicate, should not be added
+        .set_device("device a")
+        .set_device("device b")  // should overwrite existing device
         .build();
 
     assert_eq!(mfull.user_key, "abc".to_owned());
@@ -34,56 +31,14 @@ pub fn test_message_builder() {
     assert_eq!(mfull.priority, Some(0));
     assert_eq!(mfull.sound, Some("cashregister".to_owned()));
     assert_eq!(mfull.timestamp, Some(1635861224));
-    assert_eq!(mfull.devices.as_ref().unwrap().len(), 2 as usize);
-    assert_eq!(mfull.devices, Some(vec!["device a".to_owned(), "device b".to_owned()]));
+    assert_eq!(mfull.device, Some("device b".to_owned()));
 
-    /* Test devices list */
-        /* Test set devices list */
-    let devices_list: Vec<&str> = vec![
-        "device a",
-        "device b",
-        "device c",
-    ];
-    let mnext: Message = MessageBuilder::new("abc", "def", "testing")
-        .set_devices(devices_list.clone())
-        .build();
-    let list_from_mnext: Vec<String> = mnext.devices.unwrap();
-    
-    // It's ok to compare Vec<String> with Vec<&str>
-    assert_eq!(list_from_mnext, devices_list);
-    
-        /* Test merge devices list */
-    let devices_list_1: Vec<&str> = vec![
-        "device a",
-        "device b",
-    ];
-    let devices_list_2: Vec<&str> = vec![
-        "device b",
-        "device c",
-        "device a",
-    ];
-    let expected: Vec<String> = vec! [
-        "device a".to_owned(),
-        "device b".to_owned(),
-        "device c".to_owned(),
-    ];
-    let mnext_merge: Message = MessageBuilder::new("abc", "def", "testing")
-        .set_devices(devices_list_1)
-        .merge_devices(devices_list_2)
-        .build();
-    let list_from_mnext_merge: Vec<String> = mnext_merge.devices.unwrap();
-    assert_eq!(list_from_mnext_merge, expected);
-
-        /* Test clear devices list */
-    let devices_list_toclear: Vec<&str> = vec![
-        "device a",
-        "device b",
-    ];
+    /* Test clear device */
     let mnext_clear: Message = MessageBuilder::new("abc", "def", "testing")
-        .set_devices(devices_list_toclear)
-        .clear_devices_list()
+        .set_device("device a")
+        .remove_device()
         .build();
-    assert_eq!(mnext_clear.devices, None);
+    assert_eq!(mnext_clear.device, None);
 }
 
 #[test]


### PR DESCRIPTION
I believe there is a problem with the devices/device option. The API doesn't support a list of labels, but only accepts a single device label, or a group label. When looking at the JSON output of a `Message` it shows:
```
"devices": ["deviceA"]
```
which should be
```
"devices": "deviceA"
```
The Pushover API documentation is quite explicit about this (emphasis my own):

> device - the name of **one** of your devices to send just to that device instead of all devices

This pull request rewrites the code to only have a `set_device(&str)` and `remove_device()`. I also rewrote the tests. There is no test added for sending a message to a given device. A suggestion would be to add a `device` field in `credentials.json`, but it didn't feel quite right so I didn't do that yet. 

I tested the reworked code with `cargo test` and I used the new code with success to send a message to a single device or single group. I have *not* tested the code to send message with attachment to a single device.

This pull request also fixes a very minor typo in comments: conjuction -> conju***n***ction.